### PR TITLE
Fix duplicate drop impl

### DIFF
--- a/spectrogram-rs/src/main.rs
+++ b/spectrogram-rs/src/main.rs
@@ -273,18 +273,6 @@ impl Drop for SpectrogramApp {
     }
 }
 
-impl Drop for SpectrogramApp {
-    fn drop(&mut self) {
-        self.stop_audio();
-    }
-}
-
-impl Drop for SpectrogramApp {
-    fn drop(&mut self) {
-        self.stop_audio();
-    }
-}
-
 impl eframe::App for SpectrogramApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         egui::TopBottomPanel::top("controls").show(ctx, |ui| {


### PR DESCRIPTION
## Summary
- remove duplicate `Drop` trait implementations from `SpectrogramApp`
- run `cargo check` and `cargo test`

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688cf74d70608321aed6118f341c8c00