### PR TITLE
Maintain fixed history span in Rust spectrogram

### DIFF
--- a/realtime_spectrogram.py
+++ b/realtime_spectrogram.py
@@ -289,8 +289,10 @@ class MainWindow(QtWidgets.QMainWindow):
             plot.setTitle(f"{'Left' if plot == self.plot_L_spec else 'Right'} Channel Spectrogram"); plot.setLabel('left', 'Frequency', units='Hz'); plot.setLabel('bottom', 'Time', units='s')
             plot.setLogMode(x=False, y=is_log_scale); y_min_plot = np.log10(safe_plot_freq_min) if is_log_scale else plot_freq_min; y_max_plot = np.log10(plot_freq_max) if is_log_scale else plot_freq_max
             plot.setYRange(y_min_plot, y_max_plot); plot.setXRange(-HISTORY_SECONDS, 0)
-            tr = QtGui.QTransform(); freq_span_plot = y_max_plot - y_min_plot; time_span = HISTORY_SECONDS; tr.translate(-HISTORY_SECONDS, y_min_plot)
-            if self.history_frames_actual > 0 and len(self.freq_vector) > 0 and time_span > 0 and freq_span_plot > 0: tr.scale(time_span / self.history_frames_actual, freq_span_plot / len(self.freq_vector))
+            tr = QtGui.QTransform(); freq_span_plot = y_max_plot - y_min_plot; time_span = HISTORY_SECONDS
+            if self.history_frames_actual > 0 and len(self.freq_vector) > 0 and time_span > 0 and freq_span_plot > 0:
+                tr.scale(time_span / self.history_frames_actual, freq_span_plot / len(self.freq_vector))
+                tr.translate(-HISTORY_SECONDS, y_min_plot)
             else: self.print_verbose("Warning: Cannot set image transform.")
             img.setTransform(tr); gradient_item = hist.gradient; gradient_item.setColorMap(cmap); hist.setLevels(self.current_spec_db_min, self.current_spec_db_max)
         self.plot_freq_resp.setTitle("Instantaneous Frequency Response"); self.plot_freq_resp.setLabel('left', 'Magnitude', units='dBFS');

--- a/spectrogram-rs/src/main.rs
+++ b/spectrogram-rs/src/main.rs
@@ -11,6 +11,8 @@ use std::time::Duration;
 
 use eframe::egui;
 
+const HISTORY_SECONDS: f32 = 10.0;
+
 #[derive(Parser, Debug)]
 #[command(name = "spectrogram-rs", about = "Realtime audio spectrogram")]
 struct Args {
@@ -225,7 +227,7 @@ impl SpectrogramApp {
             handle: Some(handle),
             history_l: Vec::new(),
             history_r: Vec::new(),
-            max_frames: 200,
+            max_frames: ((HISTORY_SECONDS * sample_rate as f32) / chunk as f32).ceil() as usize,
             freq_bins: chunk / 2 + 1,
             tex_l: None,
             tex_r: None,
@@ -251,6 +253,7 @@ impl SpectrogramApp {
         self.running_flag = Some(running);
         self.handle = Some(handle);
         self.freq_bins = chunk / 2 + 1;
+        self.max_frames = ((HISTORY_SECONDS * self.sample_rate as f32) / self.chunk as f32).ceil() as usize;
         self.history_l.clear();
         self.history_r.clear();
         self.tex_l = None;

--- a/spectrogram-rs/src/main.rs
+++ b/spectrogram-rs/src/main.rs
@@ -209,6 +209,7 @@ struct SpectrogramApp {
     min_db: f32,
     max_db: f32,
     colormap: ColorMap,
+    interpolate: bool,
 }
 
 impl SpectrogramApp {
@@ -234,6 +235,7 @@ impl SpectrogramApp {
             min_db: -90.0,
             max_db: 0.0,
             colormap: ColorMap::default(),
+            interpolate: true,
         }
     }
 
@@ -322,6 +324,8 @@ impl eframe::App for SpectrogramApp {
                             ColorMap::Grayscale.as_str(),
                         );
                     });
+
+                ui.checkbox(&mut self.interpolate, "Interpolate");
             });
         });
 
@@ -351,21 +355,27 @@ impl eframe::App for SpectrogramApp {
             }
         }
 
+        let tex_options = if self.interpolate {
+            egui::TextureOptions::LINEAR
+        } else {
+            egui::TextureOptions::NEAREST
+        };
+
         if !pixels_l.is_empty() {
             let size = [self.history_l.len(), self.freq_bins];
             let image = egui::ColorImage::from_rgb(size, &pixels_l);
             let tex = self.tex_l.get_or_insert_with(|| {
-                ctx.load_texture("spec_l", image.clone(), Default::default())
+                ctx.load_texture("spec_l", image.clone(), tex_options)
             });
-            tex.set(image, Default::default());
+            tex.set(image, tex_options);
         }
         if !pixels_r.is_empty() {
             let size = [self.history_r.len(), self.freq_bins];
             let image = egui::ColorImage::from_rgb(size, &pixels_r);
             let tex = self.tex_r.get_or_insert_with(|| {
-                ctx.load_texture("spec_r", image.clone(), Default::default())
+                ctx.load_texture("spec_r", image.clone(), tex_options)
             });
-            tex.set(image, Default::default());
+            tex.set(image, tex_options);
         }
 
         egui::CentralPanel::default().show(ctx, |ui| {


### PR DESCRIPTION
## Summary
- Recompute the number of spectrogram frames from a constant history duration so time coverage stays consistent across chunk sizes
- Recalculate frame capacity on audio restart to respect new sample rate or chunk settings

## Testing
- `python -m py_compile realtime_spectrogram.py`
- `cd spectrogram-rs && cargo check`


------
https://chatgpt.com/codex/tasks/task_e_688e73c833d08321b52aa64f418472d8