### PR TITLE
Add configuration dialog and frequency zoom

### DIFF
--- a/spectrogram-rs/Cargo.lock
+++ b/spectrogram-rs/Cargo.lock
@@ -761,6 +761,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "colorgrad"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a5f405d474b9d05e0a093d3120e77e9bf26461b57a84b40aa2a221ac5617fb6"
+dependencies = [
+ "csscolorparser",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -894,6 +903,15 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "phf",
 ]
 
 [[package]]
@@ -2269,6 +2287,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2658,6 +2718,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
 name = "slab"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2723,6 +2789,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "colorgrad",
  "cpal",
  "eframe",
  "num-complex",

--- a/spectrogram-rs/Cargo.toml
+++ b/spectrogram-rs/Cargo.toml
@@ -10,6 +10,7 @@ num-complex = "0.4"
 clap = { version = "4.0", features = ["derive"] }
 anyhow = "1.0"
 eframe = "0.24"
+colorgrad = "0.6"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["windef", "winuser"] }

--- a/spectrogram-rs/src/main.rs
+++ b/spectrogram-rs/src/main.rs
@@ -164,6 +164,12 @@ fn compute_fft_db(samples: &[f32]) -> Vec<f32> {
 enum ColorMap {
     BlueRed,
     Grayscale,
+    Viridis,
+    Plasma,
+    Inferno,
+    Magma,
+    Cividis,
+    Turbo,
 }
 
 impl ColorMap {
@@ -171,6 +177,12 @@ impl ColorMap {
         match self {
             ColorMap::BlueRed => "Blue/Red",
             ColorMap::Grayscale => "Grayscale",
+            ColorMap::Viridis => "viridis",
+            ColorMap::Plasma => "plasma",
+            ColorMap::Inferno => "inferno",
+            ColorMap::Magma => "magma",
+            ColorMap::Cividis => "cividis",
+            ColorMap::Turbo => "turbo",
         }
     }
 
@@ -184,13 +196,37 @@ impl ColorMap {
                 let v = (t * 255.0) as u8;
                 egui::Color32::from_gray(v)
             }
+            ColorMap::Viridis => {
+                let [r, g, b, _] = colorgrad::viridis().at(t as f64).to_rgba8();
+                egui::Color32::from_rgb(r, g, b)
+            }
+            ColorMap::Plasma => {
+                let [r, g, b, _] = colorgrad::plasma().at(t as f64).to_rgba8();
+                egui::Color32::from_rgb(r, g, b)
+            }
+            ColorMap::Inferno => {
+                let [r, g, b, _] = colorgrad::inferno().at(t as f64).to_rgba8();
+                egui::Color32::from_rgb(r, g, b)
+            }
+            ColorMap::Magma => {
+                let [r, g, b, _] = colorgrad::magma().at(t as f64).to_rgba8();
+                egui::Color32::from_rgb(r, g, b)
+            }
+            ColorMap::Cividis => {
+                let [r, g, b, _] = colorgrad::cividis().at(t as f64).to_rgba8();
+                egui::Color32::from_rgb(r, g, b)
+            }
+            ColorMap::Turbo => {
+                let [r, g, b, _] = colorgrad::turbo().at(t as f64).to_rgba8();
+                egui::Color32::from_rgb(r, g, b)
+            }
         }
     }
 }
 
 impl Default for ColorMap {
     fn default() -> Self {
-        Self::BlueRed
+        Self::Viridis
     }
 }
 
@@ -210,6 +246,10 @@ struct SpectrogramApp {
     max_db: f32,
     colormap: ColorMap,
     interpolate: bool,
+    show_config: bool,
+    freq_min: f32,
+    freq_max: f32,
+    log_freq: bool,
 }
 
 impl SpectrogramApp {
@@ -236,6 +276,10 @@ impl SpectrogramApp {
             max_db: 0.0,
             colormap: ColorMap::default(),
             interpolate: true,
+            show_config: false,
+            freq_min: 20.0,
+            freq_max: sample_rate as f32 / 2.0,
+            log_freq: false,
         }
     }
 
@@ -296,38 +340,75 @@ impl eframe::App for SpectrogramApp {
                 }
 
                 ui.separator();
-
-                ui.add_enabled_ui(self.running_flag.is_none(), |ui| {
-                    ui.label("Sample Rate:");
-                    ui.add(egui::DragValue::new(&mut self.sample_rate).clamp_range(8000..=96000));
-                    ui.label("Chunk:");
-                    ui.add(egui::DragValue::new(&mut self.chunk).clamp_range(256..=8192));
-                });
-
-                ui.separator();
-                ui.label("Min dB:");
-                ui.add(egui::DragValue::new(&mut self.min_db));
-                ui.label("Max dB:");
-                ui.add(egui::DragValue::new(&mut self.max_db));
-
-                egui::ComboBox::from_id_source("colormap")
-                    .selected_text(self.colormap.as_str())
-                    .show_ui(ui, |ui| {
-                        ui.selectable_value(
-                            &mut self.colormap,
-                            ColorMap::BlueRed,
-                            ColorMap::BlueRed.as_str(),
-                        );
-                        ui.selectable_value(
-                            &mut self.colormap,
-                            ColorMap::Grayscale,
-                            ColorMap::Grayscale.as_str(),
-                        );
-                    });
-
-                ui.checkbox(&mut self.interpolate, "Interpolate");
+                if ui.button("Settings").clicked() {
+                    self.show_config = true;
+                }
             });
         });
+
+        if self.show_config {
+            let mut open = self.show_config;
+            egui::Window::new("Settings")
+                .open(&mut open)
+                .show(ctx, |ui| {
+                    ui.add_enabled_ui(self.running_flag.is_none(), |ui| {
+                        ui.label("Sample Rate:");
+                        egui::ComboBox::from_id_source("sample_rate")
+                            .selected_text(self.sample_rate.to_string())
+                            .show_ui(ui, |ui| {
+                                for &sr in [8000, 16000, 22050, 32000, 44100, 48000, 88200, 96000].iter() {
+                                    ui.selectable_value(&mut self.sample_rate, sr, sr.to_string());
+                                }
+                            });
+                        ui.label("Chunk:");
+                        egui::ComboBox::from_id_source("chunk")
+                            .selected_text(self.chunk.to_string())
+                            .show_ui(ui, |ui| {
+                                for &c in [256, 512, 1024, 2048, 4096, 8192].iter() {
+                                    ui.selectable_value(&mut self.chunk, c, c.to_string());
+                                }
+                            });
+                    });
+                    ui.separator();
+                    ui.label("Min dB:");
+                    ui.add(egui::DragValue::new(&mut self.min_db));
+                    ui.label("Max dB:");
+                    ui.add(egui::DragValue::new(&mut self.max_db));
+                    ui.separator();
+                    ui.label("Freq min (Hz):");
+                    ui.add(
+                        egui::DragValue::new(&mut self.freq_min)
+                            .clamp_range(0.0..=self.sample_rate as f64 / 2.0),
+                    );
+                    ui.label("Freq max (Hz):");
+                    ui.add(
+                        egui::DragValue::new(&mut self.freq_max)
+                            .clamp_range(0.0..=self.sample_rate as f64 / 2.0),
+                    );
+                    ui.checkbox(&mut self.log_freq, "Log frequency scale");
+                    ui.separator();
+                    egui::ComboBox::from_id_source("colormap")
+                        .selected_text(self.colormap.as_str())
+                        .show_ui(ui, |ui| {
+                            ui.selectable_value(&mut self.colormap, ColorMap::BlueRed, ColorMap::BlueRed.as_str());
+                            ui.selectable_value(&mut self.colormap, ColorMap::Grayscale, ColorMap::Grayscale.as_str());
+                            ui.selectable_value(&mut self.colormap, ColorMap::Viridis, ColorMap::Viridis.as_str());
+                            ui.selectable_value(&mut self.colormap, ColorMap::Plasma, ColorMap::Plasma.as_str());
+                            ui.selectable_value(&mut self.colormap, ColorMap::Inferno, ColorMap::Inferno.as_str());
+                            ui.selectable_value(&mut self.colormap, ColorMap::Magma, ColorMap::Magma.as_str());
+                            ui.selectable_value(&mut self.colormap, ColorMap::Cividis, ColorMap::Cividis.as_str());
+                            ui.selectable_value(&mut self.colormap, ColorMap::Turbo, ColorMap::Turbo.as_str());
+                        });
+                    ui.checkbox(&mut self.interpolate, "Interpolate");
+                    if ui.button("Apply").clicked() {
+                        if self.running_flag.is_some() {
+                            self.stop_audio();
+                            self.start_audio();
+                        }
+                    }
+                });
+            self.show_config = open;
+        }
 
         while let Ok((left, right)) = self.rx.try_recv() {
             if self.history_l.len() >= self.max_frames {
@@ -338,17 +419,36 @@ impl eframe::App for SpectrogramApp {
             self.history_r.push(right);
         }
 
+        let frames_l = &self.history_l;
+        let frames_r = &self.history_r;
+        let width = frames_l.len();
+
         let mut pixels_l: Vec<u8> = Vec::new();
         let mut pixels_r: Vec<u8> = Vec::new();
-        for y in (0..self.freq_bins).rev() {
-            for frame in &self.history_l {
-                let v = frame.get(y).copied().unwrap_or(self.min_db);
+        let display_bins = self.freq_bins;
+        let freq_min = self.freq_min.max(0.0);
+        let freq_max = self.freq_max.min(self.sample_rate as f32 / 2.0);
+        for y in (0..display_bins).rev() {
+            let frac = y as f32 / (display_bins - 1) as f32;
+            let freq = if self.log_freq {
+                if freq_min <= 0.0 {
+                    0.0
+                } else {
+                    freq_min * (freq_max / freq_min).powf(frac)
+                }
+            } else {
+                freq_min + frac * (freq_max - freq_min)
+            };
+            let bin = (((freq / self.sample_rate as f32) * self.chunk as f32).round() as usize)
+                .min(self.freq_bins - 1);
+            for frame in frames_l.iter() {
+                let v = frame.get(bin).copied().unwrap_or(self.min_db);
                 let t = ((v - self.min_db) / (self.max_db - self.min_db)).clamp(0.0, 1.0);
                 let color = self.colormap.color(t);
                 pixels_l.extend_from_slice(&[color.r(), color.g(), color.b()]);
             }
-            for frame in &self.history_r {
-                let v = frame.get(y).copied().unwrap_or(self.min_db);
+            for frame in frames_r.iter() {
+                let v = frame.get(bin).copied().unwrap_or(self.min_db);
                 let t = ((v - self.min_db) / (self.max_db - self.min_db)).clamp(0.0, 1.0);
                 let color = self.colormap.color(t);
                 pixels_r.extend_from_slice(&[color.r(), color.g(), color.b()]);
@@ -361,21 +461,12 @@ impl eframe::App for SpectrogramApp {
             egui::TextureOptions::NEAREST
         };
 
-        if !pixels_l.is_empty() {
-            let size = [self.history_l.len(), self.freq_bins];
-            let image = egui::ColorImage::from_rgb(size, &pixels_l);
-            let tex = self.tex_l.get_or_insert_with(|| {
-                ctx.load_texture("spec_l", image.clone(), tex_options)
-            });
-            tex.set(image, tex_options);
-        }
-        if !pixels_r.is_empty() {
-            let size = [self.history_r.len(), self.freq_bins];
-            let image = egui::ColorImage::from_rgb(size, &pixels_r);
-            let tex = self.tex_r.get_or_insert_with(|| {
-                ctx.load_texture("spec_r", image.clone(), tex_options)
-            });
-            tex.set(image, tex_options);
+        if width > 0 {
+            let size = [width, display_bins];
+            let image_l = egui::ColorImage::from_rgb(size, &pixels_l);
+            self.tex_l = Some(ctx.load_texture("spec_l", image_l, tex_options));
+            let image_r = egui::ColorImage::from_rgb(size, &pixels_r);
+            self.tex_r = Some(ctx.load_texture("spec_r", image_r, tex_options));
         }
 
         egui::CentralPanel::default().show(ctx, |ui| {


### PR DESCRIPTION
## Summary
- add egui settings dialog with audio, display, and frequency controls
- allow log-scale and zoomed frequency range
- keep spectrogram textures full width across chunk sizes
- expose preset color maps and dropdowns for sample rates and chunk sizes

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688e72119f3c8321b135c222fc8190f1