### PR TITLE
Throttle repaint to 60Hz and refresh on audio

### DIFF
--- a/spectrogram-rs/src/main.rs
+++ b/spectrogram-rs/src/main.rs
@@ -618,6 +618,9 @@ impl eframe::App for SpectrogramApp {
             }
         });
 
-        ctx.request_repaint();
+        if updated {
+            ctx.request_repaint();
+        }
+        ctx.request_repaint_after(Duration::from_millis(16));
     }
 }


### PR DESCRIPTION
## Summary
- limit egui repaint rate to ~60Hz when idle
- request immediate repaint when new audio frames arrive

## Testing
- `cargo test`
- `python -m py_compile realtime_spectrogram.py realtime_spectrogram.pyw build_rust.py`


------
https://chatgpt.com/codex/tasks/task_e_68900b6a4778832196b4245417603ca0